### PR TITLE
Fix exercise duration and date inputs

### DIFF
--- a/src/pages/create-exercise.tsx
+++ b/src/pages/create-exercise.tsx
@@ -78,7 +78,7 @@ export default function CreateExercise() {
                     <label>Duration (in minutes): </label>
                     <input
                         type="number"
-                        type="text"
+                        required
                         className="form-control"
                         value={duration ?? ""}
                         onChange={(e:any) => setDuration(Number(e.target.value))}

--- a/src/pages/create-exercise.tsx
+++ b/src/pages/create-exercise.tsx
@@ -89,6 +89,7 @@ export default function CreateExercise() {
                     <label>Date: </label>
                     <div>
                         <DatePicker
+                            required
                             selected={date}
                             onChange={(d) => setDate(d!)}
                         />

--- a/src/pages/create-exercise.tsx
+++ b/src/pages/create-exercise.tsx
@@ -77,6 +77,7 @@ export default function CreateExercise() {
                 <div className="form-group">
                     <label>Duration (in minutes): </label>
                     <input
+                        type="number"
                         type="text"
                         className="form-control"
                         value={duration ?? ""}

--- a/src/pages/create-exercise.tsx
+++ b/src/pages/create-exercise.tsx
@@ -79,6 +79,7 @@ export default function CreateExercise() {
                     <input
                         type="number"
                         required
+                        min={1}
                         className="form-control"
                         value={duration ?? ""}
                         onChange={(e:any) => setDuration(Number(e.target.value))}

--- a/src/pages/edit-exercise.tsx
+++ b/src/pages/edit-exercise.tsx
@@ -102,6 +102,7 @@ export function EditExercise() {
                     <input
                         type="number"
                         required
+                        min={1}
                         className="form-control"
                         value={duration}
                         onChange={(e: any) => setDuration(e.target.value)}

--- a/src/pages/edit-exercise.tsx
+++ b/src/pages/edit-exercise.tsx
@@ -101,6 +101,7 @@ export function EditExercise() {
                     <label>Duration (in minutes): </label>
                     <input
                         type="number"
+                        required
                         className="form-control"
                         value={duration}
                         onChange={(e: any) => setDuration(e.target.value)}

--- a/src/pages/edit-exercise.tsx
+++ b/src/pages/edit-exercise.tsx
@@ -100,7 +100,7 @@ export function EditExercise() {
                 <div className="form-group">
                     <label>Duration (in minutes): </label>
                     <input
-                        type="text"
+                        type="number"
                         className="form-control"
                         value={duration}
                         onChange={(e: any) => setDuration(e.target.value)}

--- a/src/pages/edit-exercise.tsx
+++ b/src/pages/edit-exercise.tsx
@@ -112,6 +112,7 @@ export function EditExercise() {
                     <label>Date: </label>
                     <div>
                         <DatePicker
+                            required
                             selected={date}
                             onChange={(e: any) => setDate(e.target.value)}
                         />


### PR DESCRIPTION
While testing with the demo on StackBlitz, I noticed that the exercise duration input had a few issues that could allow the user to input bad data and cause errors during submission as well as on the exercise list page.

I've made the following changes:
- changed the exercise duration input to be of type `number` to disallow text
- set the minimum exercise duration to `1` to prevent 0-minute duration workout entries
- made the exercise duration input required to prevent a blank value from causing an error on the exercise list
- made the date input required to prevent a blank value from causing an error on the exercise list